### PR TITLE
Added allowClear & DataList Excludes

### DIFF
--- a/code/AjaxSelect2Field.php
+++ b/code/AjaxSelect2Field.php
@@ -16,7 +16,8 @@ class AjaxSelect2Field extends TextField{
 		'minimumInputLength' 	=> 2,
 		'resultsFormat' 		=> '$Title',
 		'selectionFormat' 		=> '$Title',
-		'placeholder'			=> 'Search...'
+		'placeholder'			=> 'Search...',
+		'excludes'				=> array()
 	);
 
 
@@ -40,7 +41,7 @@ class AjaxSelect2Field extends TextField{
 			$params[$name] = $request->getVar('term');
 		}	
 		$start = (int)$request->getVar('id') ? (int)$request->getVar('id') * $this->getConfig('resultsLimit') : 0;
-		$list = $list->filterAny($params);
+		$list = $list->filterAny($params)->exclude($this->getConfig('excludes'));
 		$total = $list->count();
 		$results = $list->sort(strtok($searchFields[0], ':'), 'ASC')->limit($this->getConfig('resultsLimit'), $start);
 		

--- a/javascript/ajaxselect2.init.js
+++ b/javascript/ajaxselect2.init.js
@@ -8,6 +8,7 @@
 				    minimumInputLength: self.data('minimuminputlength'),
 				    page_limit: self.data('resultslimit'),
 				    quietMillis: 100,
+				    allowClear: true,
 				    ajax: {
 				        url: self.data('searchurl'),
 				        dataType: 'json',


### PR DESCRIPTION
Added allowClear option to Select2 init to allow native clearing of select2 element once an option has been selected.

Added DataList Excludes array to allow for extended control over the returned list.

Signed-off-by: Zann St Pierre mail@zann.com.au
