### PR TITLE
NEW Added 'multiple' option for multiselect field

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,8 @@ $field->setConfig('selectionFormat', '$Title ($ClassName)');
 
 // Configure the text displayed when no item is selected. Default is 'Search...'
 $field->setConfig('placeholder', 'Search for a Page...');
+
+// Allow selection of multiple results. NOTE - you must handle the selected IDs (comma separated list) in code
+$field->setConfig('multiple', true);
+
 ``` 

--- a/code/AjaxSelect2Field.php
+++ b/code/AjaxSelect2Field.php
@@ -18,7 +18,8 @@ class AjaxSelect2Field extends TextField{
 		'selectionFormat' 		=> '$Title',
 		'placeholder'			=> 'Search...',
 		'excludes'				=> array(),
-		'filter'				=> array()
+		'filter'				=> array(),
+		'multiple'				=> false,
 	);
 
 
@@ -91,7 +92,8 @@ class AjaxSelect2Field extends TextField{
 				'data-searchurl' => $this->Link('search'),
 				'data-minimuminputlength' => $this->getConfig('minimumInputLength'),
 				'data-resultslimit' => $this->getConfig('resultsLimit'),
-				'data-placeholder' => $this->getConfig('placeholder')
+				'data-placeholder' => $this->getConfig('placeholder'),
+				'data-multiple'		=> $this->getConfig('multiple')
 			)
 		);
 

--- a/javascript/ajaxselect2.init.js
+++ b/javascript/ajaxselect2.init.js
@@ -4,6 +4,7 @@
 			onmatch: function() {
 				var self = this;
 				self.select2({
+					multiple: self.data('multiple'),
 				    placeholder: self.data('placeholder'),
 				    minimumInputLength: self.data('minimuminputlength'),
 				    page_limit: self.data('resultslimit'),


### PR DESCRIPTION
- Allows multiple selection of items selected from ajax request
- Depends on userland code to decode the ID list set, this is
  _not_ automatically mapped back to a backing source list

Adds 'multiple' option

```
$field->setConfig('multiple', true);
```